### PR TITLE
Fix of conversion value type (int) to (boolean)

### DIFF
--- a/core/components/codemirror/elements/plugins/plugin.codemirror.php
+++ b/core/components/codemirror/elements/plugins/plugin.codemirror.php
@@ -23,7 +23,7 @@ $options = array(
 
     'indentUnit' => (int)$modx->getOption('indentUnit',$scriptProperties,$modx->getOption('indent_unit',$scriptProperties,2)),
     'smartIndent' => (boolean)$modx->getOption('smartIndent',$scriptProperties,false),
-    'tabSize' => (boolean)$modx->getOption('tabSize',$scriptProperties,4),
+    'tabSize' => (int)$modx->getOption('tabSize',$scriptProperties,4),
     'indentWithTabs' => (boolean)$modx->getOption('indentWithTabs',$scriptProperties,true),
     'electricChars' => (boolean)$modx->getOption('electricChars',$scriptProperties,true),
     'autoClearEmptyLines' => (boolean)$modx->getOption('electricChars',$scriptProperties,false),


### PR DESCRIPTION
Hi,
I found a bug with indentation in CodeMirror. After change value for settings "tabSize", CodeMirror still indent only for 1 space. 

I look into plugin code and found minor bug in variable type conversion. tabSize is integer and in script was converted to boolean (any number to boolen is value 1, so the 1 space for indenation).

Hansek
